### PR TITLE
add check for cached or out of date elasticache snapshots

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	//Version Version of the Cluster Service
-	Version = "0.2.1"
+	Version = "0.2.2"
 )


### PR DESCRIPTION
ensure that elasticache snapshots that are found through the
tagging api but may not longer exist are not attmepted to be
deleted, and gracefully handle the errors if a previously deleted
snapshot is attempted to be deleted again when it can no longer
be found.

verification:
- locate a cluster with phantom/cached snapshots
- run 'make build/cli'
- run './cli cleanup <cluster-id> -t elasticache:snapshot'
- ensure the result does not contain snapshots that do not exist
  through the aws console
- run './cli cleanup <cluster-id> -t elasticache:snapshot --dry-run=false'
- ensure the result is not a failure due to cached, not found,
  snapshots trying to be deleted'