### PR TITLE
[WIP] fix: support deletion of rds and cache subnet groups

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -20,12 +20,13 @@ func NewDefaultClient(awsSession *session.Session, logger *logrus.Entry) *Client
 	log := logger.WithField("cluster_service_provider", "aws")
 	rdsManager := NewDefaultRDSInstanceManager(awsSession, logger)
 	rdsSnapshotManager := NewDefaultRDSSnapshotManager(awsSession, logger)
+	rdsSubnetGroupManager := NewDefaultRDSSubnetGroupManager(awsSession, logger)
 	s3Manager := NewDefaultS3Engine(awsSession, logger)
 	elasticacheManager := NewDefaultElasticacheManager(awsSession, logger)
 	elasticacheSnapshotManager := NewDefaultElasticacheSnapshotManager(awsSession, logger)
 	subnetManager := NewDefaultSubnetManager(awsSession, logger)
 	return &Client{
-		ResourceManagers: []ClusterResourceManager{rdsManager, elasticacheManager, s3Manager, rdsSnapshotManager, elasticacheSnapshotManager, subnetManager},
+		ResourceManagers: []ClusterResourceManager{rdsManager, rdsSubnetGroupManager, elasticacheManager, s3Manager, rdsSnapshotManager, elasticacheSnapshotManager, subnetManager},
 		Logger:           log,
 	}
 }

--- a/pkg/aws/manager_elasticache.go
+++ b/pkg/aws/manager_elasticache.go
@@ -123,6 +123,7 @@ func (r *ElasticacheManager) DeleteResourcesForCluster(clusterId string, tags ma
 	// elasticache subnet groups do not support tagging
 	// which makes the logic a bit more tricky
 	nextSubnetGroupsToDelete := make([]string, 0)
+
 	for _, subnetGroupName := range r.subnetGroupsToDelete {
 		sgLogger := logger.WithField("subnetGroup", aws.String(subnetGroupName))
 		sgLogger.Debugf("building report for cache subnet groups")

--- a/pkg/aws/manager_elasticache.go
+++ b/pkg/aws/manager_elasticache.go
@@ -1,9 +1,11 @@
 package aws
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
@@ -17,16 +19,18 @@ import (
 var _ ClusterResourceManager = &ElasticacheManager{}
 
 type ElasticacheManager struct {
-	elasticacheClient elasticacheiface.ElastiCacheAPI
-	taggingClient     resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
-	logger            *logrus.Entry
+	elasticacheClient    elasticacheiface.ElastiCacheAPI
+	taggingClient        resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+	logger               *logrus.Entry
+	subnetGroupsToDelete []string
 }
 
 func NewDefaultElasticacheManager(session *session.Session, logger *logrus.Entry) *ElasticacheManager {
 	return &ElasticacheManager{
-		elasticacheClient: elasticache.New(session),
-		taggingClient:     resourcegroupstaggingapi.New(session),
-		logger:            logger.WithField(loggingKeyManager, managerElasticache),
+		elasticacheClient:    elasticache.New(session),
+		taggingClient:        resourcegroupstaggingapi.New(session),
+		logger:               logger.WithField(loggingKeyManager, managerElasticache),
+		subnetGroupsToDelete: make([]string, 0),
 	}
 }
 
@@ -68,6 +72,11 @@ func (r *ElasticacheManager) DeleteResourcesForCluster(clusterId string, tags ma
 				break
 			}
 			replicationGroupsToDelete = append(replicationGroupsToDelete, *cacheCluster.ReplicationGroupId)
+			// elasticache subnet groups don't support tags
+			// add the cache subnet group to the subnetGroupsToDelete list
+			// This way we can actually delete the subnet groups later on
+			// when the caches are torn down
+			r.subnetGroupsToDelete = appendIfUnique(r.subnetGroupsToDelete, *cacheCluster.CacheSubnetGroupName)
 		}
 	}
 	logger.Debugf("filtering complete, %d replicationGroups matched", len(replicationGroupsToDelete))
@@ -110,6 +119,41 @@ func (r *ElasticacheManager) DeleteResourcesForCluster(clusterId string, tags ma
 			return nil, errors.WrapLog(err, "failed to delete elasticache replication group", logger)
 		}
 	}
+	// handle deletion of orphaned cache subnet groups
+	// elasticache subnet groups do not support tagging
+	// which makes the logic a bit more tricky
+	nextSubnetGroupsToDelete := make([]string, 0)
+	for _, subnetGroupName := range r.subnetGroupsToDelete {
+		sgLogger := logger.WithField("subnetGroup", aws.String(subnetGroupName))
+		sgLogger.Debugf("building report for cache subnet groups")
+		reportItem := &clusterservice.ReportItem{
+			ID:           fmt.Sprintf("subnetgroup:%s", subnetGroupName),
+			Name:         "elasticache subnet group",
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusInProgress,
+		}
+		reportItems = append(reportItems, reportItem)
+		if dryRun {
+			sgLogger.Debug("dry run enabled, skipping deletion step")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		deleteSubnetGroupInput := &elasticache.DeleteCacheSubnetGroupInput{
+			CacheSubnetGroupName: &subnetGroupName,
+		}
+		if _, err := r.elasticacheClient.DeleteCacheSubnetGroup(deleteSubnetGroupInput); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "CacheSubnetGroupInUse" {
+				sgLogger.Debug("cache subnet group is still in use, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				// push the subnetGroup into the list of groups to be deleted next time
+				nextSubnetGroupsToDelete = append(nextSubnetGroupsToDelete, subnetGroupName)
+				continue
+			}
+			return nil, errors.WrapLog(err, "failed to delete cache subnet group", sgLogger)
+		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
+	}
+	r.subnetGroupsToDelete = nextSubnetGroupsToDelete
 	if reportItems != nil {
 		return reportItems, nil
 	}
@@ -123,4 +167,11 @@ func contains(arr []string, targetValue string) bool {
 		}
 	}
 	return false
+}
+
+func appendIfUnique(arr []string, targetValue string) []string {
+	if !contains(arr, targetValue) {
+		return append(arr, targetValue)
+	}
+	return arr
 }

--- a/pkg/aws/manager_rds_subnet_group.go
+++ b/pkg/aws/manager_rds_subnet_group.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/integr8ly/cluster-service/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	loggingKeySubnetGroup = "subnet-group-name"
+)
+
+var _ ClusterResourceManager = &RDSSubnetGroupManager{}
+
+type RDSSubnetGroupManager struct {
+	rdsClient rdsClient
+	logger    *logrus.Entry
+}
+
+func NewDefaultRDSSubnetGroupManager(session *session.Session, logger *logrus.Entry) *RDSSubnetGroupManager {
+	fmt.Println("creating new RDS Subnet Group Manager")
+	return &RDSSubnetGroupManager{
+		rdsClient: rds.New(session),
+		logger:    logger.WithField("engine", managerRDS),
+	}
+}
+
+func (r *RDSSubnetGroupManager) GetName() string {
+	return "AWS RDS Subnet Group Manager"
+}
+
+// Delete all RDS Subnet Groups for a specified cluster
+func (r *RDSSubnetGroupManager) DeleteResourcesForCluster(clusterId string, tags map[string]string, dryRun bool) ([]*clusterservice.ReportItem, error) {
+	r.logger.Debug("deleting resources for cluster")
+	subnetGroupsDescribeInput := &rds.DescribeDBSubnetGroupsInput{}
+	subnetGroupsDescribeOutput, err := r.rdsClient.DescribeDBSubnetGroups(subnetGroupsDescribeInput)
+
+	if err != nil {
+		return nil, errors.WrapLog(err, "failed to describe database subnet groups", r.logger)
+	}
+
+	var subnetGroupsToDelete []*rds.DBSubnetGroup
+
+	for _, subnetGroup := range subnetGroupsDescribeOutput.DBSubnetGroups {
+		subnetGroupLogger := r.logger.WithField(loggingKeySubnetGroup, aws.StringValue(subnetGroup.DBSubnetGroupName))
+		subnetGroupLogger.Debug("checking tags for database subnet group")
+		tagListInput := &rds.ListTagsForResourceInput{
+			ResourceName: subnetGroup.DBSubnetGroupArn,
+		}
+		tagListOutput, err := r.rdsClient.ListTagsForResource((tagListInput))
+
+		if err != nil {
+			return nil, errors.WrapLog(err, "failed to list tags for database subnet group", r.logger)
+		}
+
+		subnetGroupLogger.Debugf("checking for cluster tag match (%s=%s) on subnet group", tagKeyClusterId, clusterId)
+
+		if findTag(tagKeyClusterId, clusterId, tagListOutput.TagList) == nil {
+			subnetGroupLogger.Debugf("subnet group did not contain cluster tag match (%s=%s)", tagKeyClusterId, clusterId)
+			continue
+		}
+		subnetGroupsToDelete = append(subnetGroupsToDelete, subnetGroup)
+		r.logger.Debugf("filtering complete, %d subnet groups matched", len(subnetGroupsToDelete))
+	}
+	reportItems := make([]*clusterservice.ReportItem, 0)
+	for _, dbSubnetGroup := range subnetGroupsToDelete {
+		subnetGroupLogger := r.logger.WithField(loggingKeySubnetGroup, aws.StringValue(dbSubnetGroup.DBSubnetGroupName))
+		subnetGroupLogger.Debug("creating report for rds subnet group")
+
+		reportItem := &clusterservice.ReportItem{
+			ID:           aws.StringValue(dbSubnetGroup.DBSubnetGroupArn),
+			Name:         aws.StringValue(dbSubnetGroup.DBSubnetGroupName),
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusEmpty,
+		}
+		reportItems = append(reportItems, reportItem)
+
+		if dryRun {
+			subnetGroupLogger.Debug("dry run enabled, skipping deletion step")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		deleteInput := &rds.DeleteDBSubnetGroupInput{
+			DBSubnetGroupName: dbSubnetGroup.DBSubnetGroupName,
+		}
+
+		_, err := r.rdsClient.DeleteDBSubnetGroup(deleteInput)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "InvalidDBSubnetGroupStateFault" {
+				subnetGroupLogger.Debug("the DB subnet group cannot be deleted because it's in use, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				continue
+			}
+			return nil, errors.WrapLog(err, "failed to delete rds db subnet group", subnetGroupLogger)
+		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
+	}
+	return reportItems, nil
+}

--- a/pkg/aws/manager_rds_subnet_group_test.go
+++ b/pkg/aws/manager_rds_subnet_group_test.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/integr8ly/cluster-service/pkg/clusterservice"
 	"github.com/sirupsen/logrus"
 )
@@ -22,8 +21,9 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 	}
 
 	type fields struct {
-		rdsClient func() *rdsClientMock
-		logger    *logrus.Entry
+		rdsClient     func() *rdsClientMock
+		taggingClient func() *taggingClientMock
+		logger        *logrus.Entry
 	}
 	type args struct {
 		clusterId string
@@ -40,12 +40,21 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "error when describing subnet groups fails",
+			name: "error when getting listing resources with tagging api fails",
 			fields: fields{
 				logger: fakeLogger,
 				rdsClient: func() *rdsClientMock {
 					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
-						c.DescribeDBSubnetGroupsFunc = func(in1 *rds.DescribeDBSubnetGroupsInput) (output *rds.DescribeDBSubnetGroupsOutput, e error) {
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
 							return nil, errors.New("")
 						}
 						return nil
@@ -53,7 +62,7 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					return fakeClient
+					return client
 				},
 			},
 			args: args{
@@ -61,88 +70,13 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 				tags:      map[string]string{},
 				dryRun:    true,
 			},
-			wantErr: "failed to describe database subnet groups: ",
-		},
-		{
-			name: "error when listing tags for subnet group fails",
-			fields: fields{
-				rdsClient: func() *rdsClientMock {
-					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
-						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (output *rds.ListTagsForResourceOutput, e error) {
-							return nil, errors.New("")
-						}
-						return nil
-					})
-					if err != nil {
-						t.Fatal(err)
-					}
-					return fakeClient
-				},
-				logger: fakeLogger,
-			},
-			args: args{
-				clusterId: fakeClusterId,
-				tags:      map[string]string{},
-			},
-			wantErr: "failed to list tags for database subnet group: ",
-		},
-		{
-			name: "error when deleting subnet group fails",
-			fields: fields{
-				rdsClient: func() *rdsClientMock {
-					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
-						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (output *rds.ListTagsForResourceOutput, e error) {
-							return &rds.ListTagsForResourceOutput{
-								TagList: []*rds.Tag{
-									{
-										Key:   aws.String(fakeRDSClientTagKey),
-										Value: aws.String(fakeClusterId),
-									},
-								},
-							}, nil
-						}
-						c.DeleteDBSubnetGroupFunc = func(in *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
-							return nil, errors.New("")
-						}
-						return nil
-					})
-					if err != nil {
-						t.Fatal(err)
-					}
-					return fakeClient
-				},
-				logger: fakeLogger,
-			},
-			args: args{
-				clusterId: fakeClusterId,
-				tags:      map[string]string{},
-			},
-			wantErr: "failed to delete rds db subnet group: ",
+			wantErr: "failed to filter rds subnet groups: ",
 		},
 		{
 			name: "report empty when no subnet groups match cluster id tag",
 			fields: fields{
 				rdsClient: func() *rdsClientMock {
 					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
-						c.DescribeDBSubnetGroupsFunc = func(in1 *rds.DescribeDBSubnetGroupsInput) (*rds.DescribeDBSubnetGroupsOutput, error) {
-							return &rds.DescribeDBSubnetGroupsOutput{
-								DBSubnetGroups: []*rds.DBSubnetGroup{
-									{
-										DBSubnetGroupArn: aws.String(fakeARN),
-									},
-								},
-							}, nil
-						}
-						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error) {
-							return &rds.ListTagsForResourceOutput{
-								TagList: []*rds.Tag{
-									{
-										Key:   aws.String(tagKeyClusterId),
-										Value: aws.String("not a real clusterId"),
-									},
-								},
-							}, nil
-						}
 						return nil
 					})
 					if err != nil {
@@ -150,39 +84,27 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 					}
 					return fakeClient
 				},
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
 				logger: fakeLogger,
 			},
 			args: args{
 				clusterId: fakeClusterId,
-				// we only care about the cluster id tag for this test, leave additional tags empty
-				tags:   map[string]string{},
-				dryRun: false,
+				tags:      map[string]string{},
+				dryRun:    false,
 			},
 			want: make([]*clusterservice.ReportItem, 0),
 		},
-		// {
-		// 	name: "report empty when cluster id tag matches but additional tags do not",
-		// 	fields: fields{
-		// 		rdsClient: func() *rdsClientMock {
-		// 			fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
-		// 				return nil
-		// 			})
-		// 			if err != nil {
-		// 				t.Fatal(err)
-		// 			}
-		// 			return fakeClient
-		// 		},
-		// 		logger: fakeLogger,
-		// 	},
-		// 	args: args{
-		// 		clusterId: fakeRDSClientTagVal,
-		// 		tags: map[string]string{
-		// 			"addTagKey": "addTagVal",
-		// 		},
-		// 		dryRun: true,
-		// 	},
-		// 	want: make([]*clusterservice.ReportItem, 0),
-		// },
 		{
 			name: "no destructive methods are used when dry run is true",
 			fields: fields{
@@ -194,6 +116,15 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 						t.Fatal(err)
 					}
 					return fakeClient
+				},
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
 				},
 				logger: fakeLogger,
 			},
@@ -228,6 +159,15 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 					}
 					return fakeClient
 				},
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
 				logger: fakeLogger,
 			},
 			args: args{
@@ -243,14 +183,62 @@ func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
 					ActionStatus: clusterservice.ActionStatusSkipped,
 				},
 			},
+			wantFn: func(mock *rdsClientMock) error {
+				if len(mock.DeleteDBSubnetGroupCalls()) != 1 {
+					return errors.New("delete db subnet groups call count should be 1")
+				}
+				return nil
+			},
+		},
+		{
+			name: "item is reported as deleted when deletion is successful",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.DeleteDBSubnetGroupFunc = func(in *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
+							return &rds.DeleteDBSubnetGroupOutput{}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeRDSClientTagVal,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				{
+					ID:           fakeARN,
+					Name:         fakeResourceIdentifier,
+					Action:       clusterservice.ActionDelete,
+					ActionStatus: clusterservice.ActionStatusComplete,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			fakeTaggingClient := tt.fields.taggingClient()
 			fakeClient := tt.fields.rdsClient()
 			r := &RDSSubnetGroupManager{
-				rdsClient: fakeClient,
-				logger:    tt.fields.logger,
+				rdsClient:     fakeClient,
+				taggingClient: fakeTaggingClient,
+				logger:        tt.fields.logger,
 			}
 			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
 			if tt.wantErr != "" && err.Error() != tt.wantErr {

--- a/pkg/aws/manager_rds_subnet_group_test.go
+++ b/pkg/aws/manager_rds_subnet_group_test.go
@@ -1,0 +1,271 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/sirupsen/logrus"
+)
+
+func TestRDSSubnetGroupManager_DeleteResourcesForCluster(t *testing.T) {
+	fakeClusterId := "testClusterId"
+	fakeLogger, err := fakeLogger(func(l *logrus.Entry) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		rdsClient func() *rdsClientMock
+		logger    *logrus.Entry
+	}
+	type args struct {
+		clusterId string
+		tags      map[string]string
+		dryRun    bool
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*clusterservice.ReportItem
+		wantFn  func(mock *rdsClientMock) error
+		wantErr string
+	}{
+		{
+			name: "error when describing subnet groups fails",
+			fields: fields{
+				logger: fakeLogger,
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.DescribeDBSubnetGroupsFunc = func(in1 *rds.DescribeDBSubnetGroupsInput) (output *rds.DescribeDBSubnetGroupsOutput, e error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			wantErr: "failed to describe database subnet groups: ",
+		},
+		{
+			name: "error when listing tags for subnet group fails",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (output *rds.ListTagsForResourceOutput, e error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+			},
+			wantErr: "failed to list tags for database subnet group: ",
+		},
+		{
+			name: "error when deleting subnet group fails",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (output *rds.ListTagsForResourceOutput, e error) {
+							return &rds.ListTagsForResourceOutput{
+								TagList: []*rds.Tag{
+									{
+										Key:   aws.String(fakeRDSClientTagKey),
+										Value: aws.String(fakeClusterId),
+									},
+								},
+							}, nil
+						}
+						c.DeleteDBSubnetGroupFunc = func(in *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+			},
+			wantErr: "failed to delete rds db subnet group: ",
+		},
+		{
+			name: "report empty when no subnet groups match cluster id tag",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.DescribeDBSubnetGroupsFunc = func(in1 *rds.DescribeDBSubnetGroupsInput) (*rds.DescribeDBSubnetGroupsOutput, error) {
+							return &rds.DescribeDBSubnetGroupsOutput{
+								DBSubnetGroups: []*rds.DBSubnetGroup{
+									{
+										DBSubnetGroupArn: aws.String(fakeARN),
+									},
+								},
+							}, nil
+						}
+						c.ListTagsForResourceFunc = func(in1 *rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error) {
+							return &rds.ListTagsForResourceOutput{
+								TagList: []*rds.Tag{
+									{
+										Key:   aws.String(tagKeyClusterId),
+										Value: aws.String("not a real clusterId"),
+									},
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				// we only care about the cluster id tag for this test, leave additional tags empty
+				tags:   map[string]string{},
+				dryRun: false,
+			},
+			want: make([]*clusterservice.ReportItem, 0),
+		},
+		// {
+		// 	name: "report empty when cluster id tag matches but additional tags do not",
+		// 	fields: fields{
+		// 		rdsClient: func() *rdsClientMock {
+		// 			fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+		// 				return nil
+		// 			})
+		// 			if err != nil {
+		// 				t.Fatal(err)
+		// 			}
+		// 			return fakeClient
+		// 		},
+		// 		logger: fakeLogger,
+		// 	},
+		// 	args: args{
+		// 		clusterId: fakeRDSClientTagVal,
+		// 		tags: map[string]string{
+		// 			"addTagKey": "addTagVal",
+		// 		},
+		// 		dryRun: true,
+		// 	},
+		// 	want: make([]*clusterservice.ReportItem, 0),
+		// },
+		{
+			name: "no destructive methods are used when dry run is true",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeRDSClientTagVal,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			want: []*clusterservice.ReportItem{
+				fakeReportItemDryRun(),
+			},
+			wantFn: func(mock *rdsClientMock) error {
+				if len(mock.DeleteDBSubnetGroupCalls()) != 0 {
+					return errors.New("delete db subnet groups call count should be 0")
+				}
+				return nil
+			},
+		},
+		{
+			name: "deleting subnet group is skipped when InvalidDBSubnetGroupStateFault error is returned",
+			fields: fields{
+				rdsClient: func() *rdsClientMock {
+					fakeClient, err := fakeRDSClient(func(c *rdsClientMock) error {
+						c.DeleteDBSubnetGroupFunc = func(in *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
+							errorMsg := ""
+							return nil, awserr.New("InvalidDBSubnetGroupStateFault", errorMsg, errors.New(errorMsg))
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return fakeClient
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeRDSClientTagVal,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				{
+					ID:           fakeARN,
+					Name:         fakeResourceIdentifier,
+					Action:       clusterservice.ActionDelete,
+					ActionStatus: clusterservice.ActionStatusSkipped,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := tt.fields.rdsClient()
+			r := &RDSSubnetGroupManager{
+				rdsClient: fakeClient,
+				logger:    tt.fields.logger,
+			}
+			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("DeleteResourcesForCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !equalReportItems(got, tt.want) {
+				t.Errorf("DeleteResourcesForCluster()\n\ngot:\n\n%v\n\nwant:\n\n%v\n\n", buildReportItemsString(got), buildReportItemsString(tt.want))
+			}
+			if tt.wantFn != nil {
+				if err := tt.wantFn(fakeClient); err != nil {
+					t.Errorf("DeleteResourcesForCluster() err = %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-8129

For RDS Subnet groups, I added a new `RDSSubnetGroupManager` struct that looks after the deletion of RDS Subnet Groups. It's pretty much the same as other managers and uses tags to find which resources should be deleted.

For Elasticache subnet groups, I had to come up with a different approach. Elasticache Subnet Groups do not support AWS tags. The only way to know which subnet groups need to be deleted is by looking at the cache instances that we plan to delete. Because there are no tags, when the caches are gone you don't know which subnet groups should be deleted. So the standard approach of checking which resources need to be deleted every 30s (in watch mode) doesn't work here.

I decided to keep the subnet group names in memory across the multiple attempts to delete resources, so we can attempt to delete them once the caches are torn down. This is the only reasonable way I can think of to do this. 

**The one drawback** is that if the cli tool fails in watch mode at a particular point in time there's a possibility that we lose the ability to know which subnet groups are to be deleted. Here's how that might look.

* run the cli tool
* caches get deleted
* cli tool crashes before subnet groups are deleted
* re run cli tool
* no caches to be deleted, therefore no subnet groups to be deleted

@aidenkeating let me know if we're willing to accept the one draw back. I think we can because it's still an improvement on what we had before and if I understand things properly, we'll be porting/reusing some of this logic later on within an operator as part of the upcoming teardown work. If that's the case we'll have more options for handling those kinds of scenarios. WDYT?

TODO
- [ ] unit tests