### PR TITLE
INTLY-8162 cleanup rhmi vpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ _testmain.go
 ## Goreleaser
 dist/
 bin/
+
+cluster-service

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BUILD_TARGET=./
 
 .PHONY: build/cli
 build/cli: build/cli/local
+	mv ./cli ./cluster-service
 
 .PHONY: build/cli/local
 build/cli/local:
@@ -21,7 +22,7 @@ code/gen:
 
 .PHONY: test/unit
 test/unit:
-	go test -v ./...
+	go test -v -covermode=count ./...
 
 .PHONY: vendor/check
 vendor/check: vendor/fix

--- a/README.md
+++ b/README.md
@@ -19,13 +19,24 @@ make build/cli
 A binary will be created in the root directory of the repo, which can be run:
 
 ```
-./cli
+./cluster-service
 ```
 
 
 ### How to use
+```bash
+# set env vars for clusters aws key and secret 
+export AWS_ACCESS_KEY_ID=<key value>
+export AWS_SECRET_ACCESS_KEY=<secret value>
+```
 
-TODO
+
+```bash
+# run the cleanup command in watch mode to delete persistence resources
+./cluster-service cleanup <cluster_id> --dry-run=false --watch
+# help 
+./cluster-service cleanup --help
+```
 
 ## Testing
 
@@ -39,4 +50,4 @@ make test/unit
 
 New binaries for a release tag will be created by [GoReleaser](https://goreleaser.com/) automatically.
 
-To try out GoReleaser locally, it can be installed using `make setup/goreleaser`. 
+To try out GoReleaser locally, it can be installed using `make setup/goreleaser`.

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -24,9 +24,13 @@ func NewDefaultClient(awsSession *session.Session, logger *logrus.Entry) *Client
 	s3Manager := NewDefaultS3Engine(awsSession, logger)
 	elasticacheManager := NewDefaultElasticacheManager(awsSession, logger)
 	elasticacheSnapshotManager := NewDefaultElasticacheSnapshotManager(awsSession, logger)
+	vpcPeeringManager := NewDefaultVpcPeeringManager(awsSession, logger)
 	subnetManager := NewDefaultSubnetManager(awsSession, logger)
+	securityGroupManager := NewDefaultSecurityGroupManager(awsSession, logger)
+	routeTableManager := NewDefaultRouteTableManager(awsSession, logger)
+	vpcManager := NewDefaultVpcManager(awsSession, logger)
 	return &Client{
-		ResourceManagers: []ClusterResourceManager{rdsManager, rdsSubnetGroupManager, elasticacheManager, s3Manager, rdsSnapshotManager, elasticacheSnapshotManager, subnetManager},
+		ResourceManagers: []ClusterResourceManager{rdsManager, rdsSubnetGroupManager, elasticacheManager, s3Manager, rdsSnapshotManager, elasticacheSnapshotManager, vpcPeeringManager, subnetManager, securityGroupManager, routeTableManager, vpcManager},
 		Logger:           log,
 	}
 }

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -70,7 +70,12 @@ func TestClient_DeleteResourcesForCluster(t *testing.T) {
 					fakeDryRunEngine, err := fakeClusterManager(func(e *ClusterResourceManagerMock) error {
 						e.DeleteResourcesForClusterFunc = func(clusterId string, tags map[string]string, dryRun bool) (items []*clusterservice.ReportItem, e error) {
 							return []*clusterservice.ReportItem{
-								fakeReportItemDryRun(),
+								mockReportItem(func(item *clusterservice.ReportItem) {
+									item.ID = fakeRDSClientInstanceARN
+									item.Name = fakeResourceIdentifier
+									item.Action = clusterservice.ActionDelete
+									item.ActionStatus = clusterservice.ActionStatusDryRun
+								}),
 							}, nil
 						}
 						return nil
@@ -89,8 +94,18 @@ func TestClient_DeleteResourcesForCluster(t *testing.T) {
 			},
 			want: &clusterservice.Report{
 				Items: []*clusterservice.ReportItem{
-					fakeReportItemDeleting(),
-					fakeReportItemDryRun(),
+					mockReportItem(func(item *clusterservice.ReportItem) {
+						item.ID = fakeRDSClientInstanceARN
+						item.Name = fakeResourceIdentifier
+						item.Action = clusterservice.ActionDelete
+						item.ActionStatus = clusterservice.ActionStatusInProgress
+					}),
+					mockReportItem(func(item *clusterservice.ReportItem) {
+						item.ID = fakeRDSClientInstanceARN
+						item.Name = fakeResourceIdentifier
+						item.Action = clusterservice.ActionDelete
+						item.ActionStatus = clusterservice.ActionStatusDryRun
+					}),
 				},
 			},
 		},

--- a/pkg/aws/manager_ec2_route_table.go
+++ b/pkg/aws/manager_ec2_route_table.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/integr8ly/cluster-service/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	loggingKeyRouteTable = "route-table-id"
+
+	resourceTypeRouteTable = "ec2:route-table"
+)
+
+var _ ClusterResourceManager = &RouteTableManager{}
+
+type RouteTableManager struct {
+	ec2Client     ec2Client
+	taggingClient taggingClient
+	logger        *logrus.Entry
+}
+
+func NewDefaultRouteTableManager(session *session.Session, logger *logrus.Entry) *RouteTableManager {
+	return &RouteTableManager{
+		ec2Client:     ec2.New(session),
+		taggingClient: resourcegroupstaggingapi.New(session),
+		logger:        logger.WithField(loggingKeyManager, managerRouteTable),
+	}
+}
+
+func (r *RouteTableManager) GetName() string {
+	return "AWS EC2 RouteTable Manager"
+}
+
+func (r *RouteTableManager) DeleteResourcesForCluster(clusterId string, tags map[string]string, dryRun bool) ([]*clusterservice.ReportItem, error) {
+	r.logger.Debug("delete route table resources for cluster")
+	resourceInput := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{resourceTypeRouteTable}),
+		TagFilters:          convertClusterTagsToAWSTagFilter(clusterId, tags),
+	}
+	resourceOutput, err := r.taggingClient.GetResources(resourceInput)
+	if err != nil {
+		return nil, errors.WrapLog(err, "failed to filter route tables", r.logger)
+	}
+	var routeTablesToDelete []*basicResource
+	for _, resourceTagMapping := range resourceOutput.ResourceTagMappingList {
+		arn := aws.StringValue(resourceTagMapping.ResourceARN)
+		arnElements := strings.Split(arn, "/")
+		routeTableId := arnElements[len(arnElements)-1]
+		if routeTableId == "" {
+			return nil, errors.WrapLog(err, fmt.Sprintf("invalid route table name from arn, %s", routeTableId), r.logger)
+		}
+		routeTablesToDelete = append(routeTablesToDelete, &basicResource{
+			Name: routeTableId,
+			ARN:  arn,
+		})
+	}
+	r.logger.Debugf("found list of %d route tables to delete", len(routeTablesToDelete))
+	//delete resources
+	var reportItems []*clusterservice.ReportItem
+	for _, routeTable := range routeTablesToDelete {
+		routeTableLogger := r.logger.WithField(loggingKeyRouteTable, routeTable.Name)
+		reportItem := &clusterservice.ReportItem{
+			ID:           routeTable.ARN,
+			Name:         routeTable.Name,
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusInProgress,
+		}
+		reportItems = append(reportItems, reportItem)
+		if dryRun {
+			routeTableLogger.Debugf("dry run is enabled, skipping deletion")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		routeTableLogger.Debugf("performing route table deletion")
+		deleteRouteTableInput := &ec2.DeleteRouteTableInput{
+			RouteTableId: aws.String(routeTable.Name),
+		}
+		if _, err := r.ec2Client.DeleteRouteTable(deleteRouteTableInput); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DependencyViolation" {
+				routeTableLogger.Debug("route table has existing dependencies which have not been deleted, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				continue
+			}
+
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "InvalidRouteTableID.NotFound" {
+				routeTableLogger.Debug("route does not exist, assuming deleted")
+				reportItem.ActionStatus = clusterservice.ActionStatusComplete
+				continue
+			}
+			return nil, errors.WrapLog(err, "failed to delete route table", r.logger)
+		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
+	}
+	return reportItems, nil
+}

--- a/pkg/aws/manager_ec2_security_group.go
+++ b/pkg/aws/manager_ec2_security_group.go
@@ -1,0 +1,106 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/integr8ly/cluster-service/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	loggingKeySecurityGroup = "security-group-id"
+
+	resourceTypeSecurtyGroup = "ec2:security-group"
+)
+
+var _ ClusterResourceManager = &SecurityGroupManager{}
+
+// SecurityGroupManager type
+type SecurityGroupManager struct {
+	ec2Client     ec2Client
+	taggingClient taggingClient
+	logger        *logrus.Entry
+}
+
+// NewDefaultSecurityGroupManager create session for manager
+func NewDefaultSecurityGroupManager(session *session.Session, logger *logrus.Entry) *SecurityGroupManager {
+	return &SecurityGroupManager{
+		ec2Client:     ec2.New(session),
+		taggingClient: resourcegroupstaggingapi.New(session),
+		logger:        logger.WithField(loggingKeyManager, managerSecurityGroup),
+	}
+}
+
+// GetName getter function
+func (r *SecurityGroupManager) GetName() string {
+	return "AWS EC2 SecurityGroup Manager"
+}
+
+// DeleteResourcesForCluster deletes resource for cluster
+func (r *SecurityGroupManager) DeleteResourcesForCluster(clusterId string, tags map[string]string, dryRun bool) ([]*clusterservice.ReportItem, error) {
+	var securityGroupsToDelete []*basicResource
+	r.logger.Debug("delete security groups resources for cluster")
+	//  integreatly.org/clusterID tags
+	resourceInput := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{resourceTypeSecurtyGroup}),
+		TagFilters:          convertClusterTagsToAWSTagFilter(clusterId, tags),
+	}
+	// add to the security group delete array
+	resourceOutput, err := r.taggingClient.GetResources(resourceInput)
+	if err != nil {
+		return nil, errors.WrapLog(err, "failed to filter security groups", r.logger)
+	}
+
+	for _, resourceTagMapping := range resourceOutput.ResourceTagMappingList {
+		arn := aws.StringValue(resourceTagMapping.ResourceARN)
+		arnElements := strings.Split(arn, "/")
+		securityGroupID := arnElements[len(arnElements)-1]
+		if securityGroupID == "" {
+			return nil, errors.WrapLog(err, fmt.Sprintf("invalid security groups name from arn, %s", securityGroupID), r.logger)
+		}
+		securityGroupsToDelete = append(securityGroupsToDelete, &basicResource{
+			Name: securityGroupID,
+			ARN:  arn,
+		})
+		r.logger.Debugf("found list of %d security groups to delete", len(securityGroupsToDelete))
+	}
+	//delete resources
+	var reportItems []*clusterservice.ReportItem
+	for _, securityGroup := range securityGroupsToDelete {
+		securityGroupLogger := r.logger.WithField(loggingKeySecurityGroup, securityGroup.Name)
+		reportItem := &clusterservice.ReportItem{
+			ID:           securityGroup.ARN,
+			Name:         securityGroup.Name,
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusInProgress,
+		}
+		reportItems = append(reportItems, reportItem)
+		if dryRun {
+			securityGroupLogger.Debugf("dry run is enabled, skipping deletion")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		securityGroupLogger.Debugf("performing security group deletion")
+		deleteSecurityGroupInput := &ec2.DeleteSecurityGroupInput{
+			GroupId: aws.String(securityGroup.Name),
+		}
+		if _, err := r.ec2Client.DeleteSecurityGroup(deleteSecurityGroupInput); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DependencyViolation" {
+				securityGroupLogger.Debug("security group has existing dependencies which have not been deleted, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				continue
+			}
+			return nil, errors.WrapLog(err, "failed to delete security group", r.logger)
+		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
+	}
+	return reportItems, nil
+}

--- a/pkg/aws/manager_ec2_security_group_test.go
+++ b/pkg/aws/manager_ec2_security_group_test.go
@@ -1,0 +1,208 @@
+package aws
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/sirupsen/logrus"
+)
+
+func TestSecurityGroupManager_DeleteResourcesForCluster(t *testing.T) {
+	fakeLogger, err := fakeLogger(func(l *logrus.Entry) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		taggingClient func() *taggingClientMock
+		logger        *logrus.Entry
+		Ec2Api        ec2iface.EC2API
+	}
+	type args struct {
+		clusterId string
+		tags      map[string]string
+		dryRun    bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*clusterservice.ReportItem
+		wantErr string
+	}{
+		{
+			name: "fail when getting resources via tags returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSecurityGroupFn = func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+						return &ec2.DeleteSecurityGroupOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return nil, errors.New("some tagging error")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to filter security groups: some tagging error",
+		},
+		{
+			name: "fail when security group deletion returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSecurityGroupFn = func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+						return nil, errors.New("some error deleting security group")
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to delete security group: some error deleting security group",
+		},
+		{
+			name: "succeeds with status completed if dry run is false and no errors on delete aka successful deletion",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSecurityGroupFn = func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+						return &ec2.DeleteSecurityGroupOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
+			},
+		},
+		{
+			name: "succeeds with status dry run if dry run is true",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSecurityGroupFn = func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+						return &ec2.DeleteSecurityGroupOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &SecurityGroupManager{
+				ec2Client:     tt.fields.Ec2Api,
+				taggingClient: tt.fields.taggingClient(),
+				logger:        tt.fields.logger,
+			}
+			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("DeleteResourcesForCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", buildReportItemsString(got), buildReportItemsString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/aws/manager_ec2_subnet.go
+++ b/pkg/aws/manager_ec2_subnet.go
@@ -93,6 +93,8 @@ func (s *SubnetManager) DeleteResourcesForCluster(clusterId string, tags map[str
 			}
 			return nil, errors.WrapLog(err, "failed to delete subnet", s.logger)
 		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
 	}
+
 	return reportItems, nil
 }

--- a/pkg/aws/manager_ec2_subnet_test.go
+++ b/pkg/aws/manager_ec2_subnet_test.go
@@ -1,0 +1,208 @@
+package aws
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/sirupsen/logrus"
+)
+
+func TestSubnetManager_DeleteResourcesForCluster(t *testing.T) {
+	fakeLogger, err := fakeLogger(func(l *logrus.Entry) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		taggingClient func() *taggingClientMock
+		logger        *logrus.Entry
+		Ec2Api        ec2iface.EC2API
+	}
+	type args struct {
+		clusterId string
+		tags      map[string]string
+		dryRun    bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*clusterservice.ReportItem
+		wantErr string
+	}{
+		{
+			name: "fail when getting resources via tags returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSubnetFn = func(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+						return &ec2.DeleteSubnetOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to filter subnets: ",
+		},
+		{
+			name: "fail when subnet deletion returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSubnetFn = func(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+						return nil, errors.New("some error deleting subnet")
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to delete subnet: some error deleting subnet",
+		},
+		{
+			name: "succeeds with status completed if dry run is false and no errors on delete aka successful deletion",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSubnetFn = func(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+						return &ec2.DeleteSubnetOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
+			},
+		},
+		{
+			name: "succeeds with status dry run if dry run is true",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteSubnetFn = func(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+						return &ec2.DeleteSubnetOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &SubnetManager{
+				ec2Client:     tt.fields.Ec2Api,
+				taggingClient: tt.fields.taggingClient(),
+				logger:        tt.fields.logger,
+			}
+			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("DeleteResourcesForCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", buildReportItemsString(got), buildReportItemsString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/aws/manager_ec2_vpc.go
+++ b/pkg/aws/manager_ec2_vpc.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/integr8ly/cluster-service/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	loggingKeyVpc = "vpc-id"
+
+	resourceTypeVpc = "ec2:vpc"
+)
+
+var _ ClusterResourceManager = &VpcManager{}
+
+// VpcManager type
+type VpcManager struct {
+	ec2Client     ec2Client
+	taggingClient taggingClient
+	logger        *logrus.Entry
+}
+
+// NewDefaultVpcManager create session for manager
+func NewDefaultVpcManager(session *session.Session, logger *logrus.Entry) *VpcManager {
+	return &VpcManager{
+		ec2Client:     ec2.New(session),
+		taggingClient: resourcegroupstaggingapi.New(session),
+		logger:        logger.WithField(loggingKeyManager, managerVpc),
+	}
+}
+
+// GetName getter function
+func (r *VpcManager) GetName() string {
+	return "AWS EC2 Vpc Manager"
+}
+
+// DeleteResourcesForCluster deletes resource for cluster
+func (r *VpcManager) DeleteResourcesForCluster(clusterId string, tags map[string]string, dryRun bool) ([]*clusterservice.ReportItem, error) {
+	var vpcsToDelete []*basicResource
+	r.logger.Debug("delete vpc resources for cluster")
+	//  integreatly.org/clusterID tags
+	resourceInput := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{resourceTypeVpc}),
+		TagFilters:          convertClusterTagsToAWSTagFilter(clusterId, tags),
+	}
+	// add to the vpc delete array
+	resourceOutput, err := r.taggingClient.GetResources(resourceInput)
+	if err != nil {
+		return nil, errors.WrapLog(err, "failed to filter vpc", r.logger)
+	}
+	for _, resourceTagMapping := range resourceOutput.ResourceTagMappingList {
+		arn := aws.StringValue(resourceTagMapping.ResourceARN)
+		arnElements := strings.Split(arn, "/")
+		vpcID := arnElements[len(arnElements)-1]
+		if vpcID == "" {
+			return nil, errors.WrapLog(err, fmt.Sprintf("invalid vpc name from arn, %s", vpcID), r.logger)
+		}
+		vpcsToDelete = append(vpcsToDelete, &basicResource{
+			Name: vpcID,
+			ARN:  arn,
+		})
+	}
+
+	r.logger.Debugf("found list of %d vpc to delete", len(vpcsToDelete))
+	//delete resources
+	var reportItems []*clusterservice.ReportItem
+	for _, vpc := range vpcsToDelete {
+		vpcLogger := r.logger.WithField(loggingKeyVpc, vpc.Name)
+		reportItem := &clusterservice.ReportItem{
+			ID:           vpc.ARN,
+			Name:         vpc.Name,
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusInProgress,
+		}
+		reportItems = append(reportItems, reportItem)
+		if dryRun {
+			vpcLogger.Debugf("dry run is enabled, skipping deletion")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		vpcLogger.Debugf("performing vpc deletion")
+		deleteVpcInput := &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpc.Name),
+		}
+		if _, err := r.ec2Client.DeleteVpc(deleteVpcInput); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DependencyViolation" {
+				vpcLogger.Debug("vpc has existing dependencies which have not been deleted, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				continue
+			}
+			return nil, errors.WrapLog(err, "failed to delete vpc", r.logger)
+		}
+	}
+	return reportItems, nil
+}

--- a/pkg/aws/manager_ec2_vpc_peering.go
+++ b/pkg/aws/manager_ec2_vpc_peering.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/integr8ly/cluster-service/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	loggingKeyVpcPeeringConnection = "vpc-peering-id"
+
+	resourceTypeVpcPeeringConnection = "ec2:vpc-peering-connection"
+)
+
+var _ ClusterResourceManager = &VpcPeeringManager{}
+
+// VpcPeeringManager type
+type VpcPeeringManager struct {
+	ec2Client     ec2Client
+	taggingClient taggingClient
+	logger        *logrus.Entry
+}
+
+// NewDefaultVpcPeeringManager create session for manager
+func NewDefaultVpcPeeringManager(session *session.Session, logger *logrus.Entry) *VpcPeeringManager {
+	return &VpcPeeringManager{
+		ec2Client:     ec2.New(session),
+		taggingClient: resourcegroupstaggingapi.New(session),
+		logger:        logger.WithField(loggingKeyManager, managerVpcPeering),
+	}
+}
+
+// GetName getter function
+func (r *VpcPeeringManager) GetName() string {
+	return "AWS EC2 Vpc Peering Connection Manager"
+}
+
+// DeleteResourcesForCluster deletes resource for cluster
+func (r *VpcPeeringManager) DeleteResourcesForCluster(clusterId string, tags map[string]string, dryRun bool) ([]*clusterservice.ReportItem, error) {
+	var vpcPeeringConnectionsToDelete []*basicResource
+	r.logger.Debug("delete vpc peering connections resources for cluster")
+	resourceInput := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{resourceTypeVpcPeeringConnection}),
+		TagFilters:          convertClusterTagsToAWSTagFilter(clusterId, tags),
+	}
+	// add to the vpc peering delete array
+	resourceOutput, err := r.taggingClient.GetResources(resourceInput)
+	if err != nil {
+		return nil, errors.WrapLog(err, "failed to filter vpc peering connections", r.logger)
+	}
+
+	for _, resourceTagMapping := range resourceOutput.ResourceTagMappingList {
+		arn := aws.StringValue(resourceTagMapping.ResourceARN)
+		arnElements := strings.Split(arn, "/")
+		vpcPeeringConnectionID := arnElements[len(arnElements)-1]
+		if vpcPeeringConnectionID == "" {
+			return nil, errors.WrapLog(err, fmt.Sprintf("invalid vpc peering connection name from arn, %s", vpcPeeringConnectionID), r.logger)
+		}
+		vpcPeeringConnectionsToDelete = append(vpcPeeringConnectionsToDelete, &basicResource{
+			Name: vpcPeeringConnectionID,
+			ARN:  arn,
+		})
+		r.logger.Debugf("found list of %d vpc peering connection to delete", len(vpcPeeringConnectionsToDelete))
+	}
+	//delete resources
+	var reportItems []*clusterservice.ReportItem
+	for _, vpcPeeringConnection := range vpcPeeringConnectionsToDelete {
+		vpcPeeringConnectionLogger := r.logger.WithField(loggingKeyVpcPeeringConnection, vpcPeeringConnection.Name)
+		reportItem := &clusterservice.ReportItem{
+			ID:           vpcPeeringConnection.ARN,
+			Name:         vpcPeeringConnection.Name,
+			Action:       clusterservice.ActionDelete,
+			ActionStatus: clusterservice.ActionStatusInProgress,
+		}
+		reportItems = append(reportItems, reportItem)
+		if dryRun {
+			vpcPeeringConnectionLogger.Debugf("dry run is enabled, skipping deletion")
+			reportItem.ActionStatus = clusterservice.ActionStatusDryRun
+			continue
+		}
+		vpcPeeringConnectionLogger.Debugf("performing vpc peering connection deletion")
+		deleteVpcPeeringConnectionInput := &ec2.DeleteVpcPeeringConnectionInput{
+			VpcPeeringConnectionId: aws.String(vpcPeeringConnection.Name),
+		}
+
+		if _, err := r.ec2Client.DeleteVpcPeeringConnection(deleteVpcPeeringConnectionInput); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "DependencyViolation" {
+				vpcPeeringConnectionLogger.Debug("vpc peering connection has existing dependencies which have not been deleted, skipping")
+				reportItem.ActionStatus = clusterservice.ActionStatusSkipped
+				r.logger.Infof("Error: %s, %s", awsErr.Code(), awsErr.Message())
+				continue
+			}
+
+			// in the case of vpc peerings they are picked up on describe but then when attempting to delete they are not found
+			// any that are not found can be skipped.
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "InvalidVpcPeeringConnectionID.NotFound" {
+				vpcPeeringConnectionLogger.Debug("vpc peering connection does not exist, assume deleted")
+				reportItem.ActionStatus = clusterservice.ActionStatusComplete
+				continue
+			}
+
+			return nil, errors.WrapLog(err, "failed to delete vpc peering connection", r.logger)
+		}
+		reportItem.ActionStatus = clusterservice.ActionStatusComplete
+	}
+	return reportItems, nil
+}

--- a/pkg/aws/manager_ec2_vpc_peering_test.go
+++ b/pkg/aws/manager_ec2_vpc_peering_test.go
@@ -1,0 +1,251 @@
+package aws
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/sirupsen/logrus"
+)
+
+func TestVpcPeeringManager_DeleteResourcesForCluster(t *testing.T) {
+	fakeLogger, err := fakeLogger(func(l *logrus.Entry) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		taggingClient func() *taggingClientMock
+		logger        *logrus.Entry
+		Ec2Api        ec2iface.EC2API
+	}
+	type args struct {
+		clusterId string
+		tags      map[string]string
+		dryRun    bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*clusterservice.ReportItem
+		wantErr string
+	}{
+		{
+			name: "do not fail when getting peering connection NotFound",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcPeeringConnectionFn = func(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+						return nil, awserr.New("InvalidVpcPeeringConnectionID.NotFound", "", errors.New("InvalidVpcPeeringConnectionID.NotFound"))
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
+			},
+		},
+		{
+			name: "fail when getting resources via tags returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcPeeringConnectionFn = func(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+						return &ec2.DeleteVpcPeeringConnectionOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to filter vpc peering connections: ",
+		},
+		{
+			name: "fail when vpc peering connection deletion returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcPeeringConnectionFn = func(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+						return nil, errors.New("some error deleting vpc peering connection")
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to delete vpc peering connection: some error deleting vpc peering connection",
+		},
+		{
+			name: "succeeds with status completed if dry run is false and no errors on delete aka successful deletion",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcPeeringConnectionFn = func(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+						return &ec2.DeleteVpcPeeringConnectionOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
+			},
+		},
+		{
+			name: "succeeds with status dry run if dry run is true",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcPeeringConnectionFn = func(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+						return &ec2.DeleteVpcPeeringConnectionOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VpcPeeringManager{
+				ec2Client:     tt.fields.Ec2Api,
+				taggingClient: tt.fields.taggingClient(),
+				logger:        tt.fields.logger,
+			}
+			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("DeleteResourcesForCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", buildReportItemsString(got), buildReportItemsString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/aws/manager_ec2_vpc_test.go
+++ b/pkg/aws/manager_ec2_vpc_test.go
@@ -1,0 +1,208 @@
+package aws
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/integr8ly/cluster-service/pkg/clusterservice"
+	"github.com/sirupsen/logrus"
+)
+
+func TestVpcManager_DeleteResourcesForCluster(t *testing.T) {
+	fakeLogger, err := fakeLogger(func(l *logrus.Entry) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		taggingClient func() *taggingClientMock
+		logger        *logrus.Entry
+		Ec2Api        ec2iface.EC2API
+	}
+	type args struct {
+		clusterId string
+		tags      map[string]string
+		dryRun    bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*clusterservice.ReportItem
+		wantErr string
+	}{
+		{
+			name: "fail when getting resources via tags returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcFn = func(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+						return &ec2.DeleteVpcOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (output *resourcegroupstaggingapi.GetResourcesOutput, e error) {
+							return nil, errors.New("")
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to filter vpc: ",
+		},
+		{
+			name: "fail when vpc deletion returns an error",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcFn = func(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+						return nil, errors.New("some error deleting vpc")
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			wantErr: "failed to delete vpc: some error deleting vpc",
+		},
+		{
+			name: "succeeds with status completed if dry run is false and no errors on delete aka successful deletion",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcFn = func(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+						return &ec2.DeleteVpcOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    false,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
+			},
+		},
+		{
+			name: "succeeds with status dry run if dry run is true",
+			fields: fields{
+				Ec2Api: buildMockEc2Client(func(ec2Client *mockEc2Client) {
+					ec2Client.deleteVpcFn = func(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+						return &ec2.DeleteVpcOutput{}, nil
+					}
+				}),
+				taggingClient: func() *taggingClientMock {
+					client, err := fakeTaggingClient(func(c *taggingClientMock) error {
+						c.GetResourcesFunc = func(in1 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+							return &resourcegroupstaggingapi.GetResourcesOutput{
+								ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+									fakeResourceTagMapping(func(mapping *resourcegroupstaggingapi.ResourceTagMapping) {
+										mapping.ResourceARN = aws.String(fakeEc2ClientInstanceArn)
+									}),
+								},
+							}, nil
+						}
+						return nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return client
+				},
+				logger: fakeLogger,
+			},
+			args: args{
+				clusterId: fakeClusterId,
+				tags:      map[string]string{},
+				dryRun:    true,
+			},
+			want: []*clusterservice.ReportItem{
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeEc2ClientInstanceArn
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VpcManager{
+				ec2Client:     tt.fields.Ec2Api,
+				taggingClient: tt.fields.taggingClient(),
+				logger:        tt.fields.logger,
+			}
+			got, err := r.DeleteResourcesForCluster(tt.args.clusterId, tt.args.tags, tt.args.dryRun)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("DeleteResourcesForCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", buildReportItemsString(got), buildReportItemsString(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/aws/manager_elasticache_snapshot_test.go
+++ b/pkg/aws/manager_elasticache_snapshot_test.go
@@ -130,7 +130,12 @@ func TestElasticacheSnapshotManager_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemElasticacheSnapshotDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
 			},
 			wantErr: "",
 		},
@@ -169,7 +174,12 @@ func TestElasticacheSnapshotManager_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    true,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemElasticacheSnapshotDryRun(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
 			},
 			wantFn: func(mock *elasticacheClientMock) error {
 				if len(mock.DeleteSnapshotCalls()) != 0 {

--- a/pkg/aws/manager_elasticache_test.go
+++ b/pkg/aws/manager_elasticache_test.go
@@ -258,8 +258,18 @@ func TestElasticacheEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDeleting(),
-				fakeReportItemCacheSubnetGroupComplete(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
 			},
 			wantErr: "",
 		}, {
@@ -299,8 +309,18 @@ func TestElasticacheEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDeleting(),
-				fakeReportItemCacheSubnetGroupComplete(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+				}),
 			},
 			wantFn: func(mock *elasticacheClientMock) error {
 				if len(mock.DeleteReplicationGroupCalls()) != 0 {
@@ -343,8 +363,18 @@ func TestElasticacheEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    true,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDryRun(),
-				fakeReportItemCacheSubnetGroupDryRun(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
 			},
 			wantFn: func(mock *elasticacheClientMock) error {
 				if len(mock.DeleteReplicationGroupCalls()) != 0 {
@@ -384,8 +414,18 @@ func TestElasticacheEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDeleting(),
-				fakeReportItemCacheSubnetGroupSkipped(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusSkipped
+				}),
 			},
 		},
 	}
@@ -488,14 +528,36 @@ func TestElasticacheEngine_DeleteSubnetGroupsAcrossMultipleAttempts(t *testing.T
 	}{
 		{
 			wantReport: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDeleting(),
-				fakeReportItemCacheSubnetGroupSkipped(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusSkipped
+				}),
 			},
 			wantSubnetGroupsToDeleteLength: 1,
 		}, {
 			wantReport: []*clusterservice.ReportItem{
-				fakeReportItemReplicationGroupDeleting(),
-				fakeReportItemCacheSubnetGroupComplete(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeElasticacheClientReplicationGroupId
+					item.Name = fakeElasticacheClientName
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusComplete
+					item.ID = fakeElasticacheSubnetGroupID
+					item.Name = fakeElasticacheSubnetGroupName
+				}),
 			},
 			wantSubnetGroupsToDeleteLength: 0,
 		},

--- a/pkg/aws/manager_rds_snapshot_test.go
+++ b/pkg/aws/manager_rds_snapshot_test.go
@@ -64,7 +64,13 @@ func TestRDSSnapshotManager_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemRDSSnapshotDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
 			},
 			wantErr: false,
 		}, {
@@ -167,7 +173,12 @@ func TestRDSSnapshotManager_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    true,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemRDSSnapshotDryRun(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.DeleteDBSnapshotCalls()) != 0 {

--- a/pkg/aws/manager_rds_test.go
+++ b/pkg/aws/manager_rds_test.go
@@ -154,7 +154,13 @@ func TestRDSEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeRDSClientInstanceARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.ModifyDBInstanceCalls()) != 1 {
@@ -195,7 +201,13 @@ func TestRDSEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeRDSClientInstanceARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.ModifyDBInstanceCalls()) != 0 {
@@ -227,7 +239,12 @@ func TestRDSEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    true,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDryRun(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeRDSClientInstanceARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.ModifyDBInstanceCalls()) != 0 {
@@ -268,7 +285,13 @@ func TestRDSEngine_DeleteResourcesForCluster(t *testing.T) {
 				tags:      map[string]string{},
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeRDSClientInstanceARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.DeleteDBInstanceCalls()) != 0 {
@@ -297,7 +320,12 @@ func TestRDSEngine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeRDSClientInstanceARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
 			},
 			wantFn: func(mock *rdsClientMock) error {
 				if len(mock.DeleteDBInstanceCalls()) != 1 {

--- a/pkg/aws/manager_s3_test.go
+++ b/pkg/aws/manager_s3_test.go
@@ -189,7 +189,12 @@ func TestS3Engine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    false,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDeleting(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeResourceTagMappingARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusInProgress
+				}),
 			},
 		},
 		{
@@ -230,7 +235,12 @@ func TestS3Engine_DeleteResourcesForCluster(t *testing.T) {
 				dryRun:    true,
 			},
 			want: []*clusterservice.ReportItem{
-				fakeReportItemDryRun(),
+				mockReportItem(func(item *clusterservice.ReportItem) {
+					item.ID = fakeResourceTagMappingARN
+					item.Name = fakeResourceIdentifier
+					item.Action = clusterservice.ActionDelete
+					item.ActionStatus = clusterservice.ActionStatusDryRun
+				}),
 			},
 		},
 	}
@@ -248,7 +258,7 @@ func TestS3Engine_DeleteResourcesForCluster(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", got, tt.want)
+				t.Errorf("DeleteResourcesForCluster() got = %v, want %v", buildReportItemsString(got), buildReportItemsString(tt.want))
 			}
 		})
 	}

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -19,9 +19,13 @@ const (
 	managerRDS                 ResourceManagerType = "aws_rds"
 	managerS3                  ResourceManagerType = "aws_s3"
 	managerSubnet              ResourceManagerType = "aws_ec2_subnet"
+	managerVpc                 ResourceManagerType = "aws_ec2_vpc"
+	managerVpcPeering          ResourceManagerType = "aws_ec2_vpc_peering"
 	managerRDSSnapshot         ResourceManagerType = "aws_rds_snapshot"
 	managerElasticache         ResourceManagerType = "aws_elasticache"
 	managerElasticacheSnapshot ResourceManagerType = "aws_elasticache_snapshot"
+	managerSecurityGroup       ResourceManagerType = "aws_ec2_security_group"
+	managerRouteTable          ResourceManagerType = "aws_ec2_route_table"
 
 	loggingKeyClusterID = "cluster-id"
 	loggingKeyDryRun    = "dry-run"


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/INTLY-8162

**Verification**

Using a byoc cluster run `cloud-resource-operator` to create the new network resources with the following steps.

- Log into the cluster using `ocm_cluster_login <cluster-name>`
- Run `make cluster/prepare NAMESPACE=<yournamespace>
- Run `make cluster/seed/managed/postgres`
- Run `make cluster/seed/managed/redis`
- Run `make run`

Verify that the expected resources are created in aws. e.g. (in ec2: vpc, vpcpeering, routetable, 2 subnets, security groups, in rds: subnetgroup, rds, in elasticache: elasticache cluster, subnetgroup) with the tag `RHMI Cloud Resource <ResourceType>`

- Stop CRO (this step is required or it will continually reconcile and create new resources as cluster-service deletes them) 

- Run `make build/cli` for this pr
- Run `./cluster-service cleanup <clusterid> --dry-run=false --watch`

The expected outcome is that the cli will loop on `has dependencies and cannot be deleted` until the dependencies get deleted. Eventually all dependency resources will be deleted and the vpc will be last resource to be deleted.
E.g.
```bash
+-----------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+--------+----------+
|                                                    ID                                                     |                           NAME                            | ACTION |  STATUS  |
+-----------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+--------+----------+
| arn:aws:rds:eu-west-1:485026278258:db:mwcolabbyocvwm48cloudresourceoperat-snyu                            | mwcolabbyocvwm48cloudresourceoperat-snyu                  | delete | complete |
| arn:aws:rds:eu-west-1:485026278258:subgrp:mwcolabbyocvwm48subnetgroup                                     | mwcolabbyocvwm48subnetgroup                               | delete | complete |
| mwcolabbyocvwm48cloudresourceoperat-lohz                                                                  | elasticache Replication group                             | delete | complete |
| subnetgroup:mwcolabbyocvwm48subnetgroup                                                                   | elasticache subnet group                                  | delete | complete |
| arn:aws:rds:eu-west-1:485026278258:snapshot:mwcolabbyocvwm48cloudresourceoperat-rrq4                      | mwcolabbyocvwm48cloudresourceoperat-rrq4                  | delete | complete |
| arn:aws:rds:eu-west-1:485026278258:snapshot:rds:mwcolabbyocvwm48cloudresourceoperat-snyu-2020-06-30-14-46 | mwcolabbyocvwm48cloudresourceoperat-snyu-2020-06-30-14-46 | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-0f8f883bf3cb0df06                           | pcx-0f8f883bf3cb0df06                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-0c300547a4c1a4ab2                           | pcx-0c300547a4c1a4ab2                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-015fdd2ec9065aa9a                           | pcx-015fdd2ec9065aa9a                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-0cb3c1d893da46e3f                           | pcx-0cb3c1d893da46e3f                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-09218faea7c9c8005                           | pcx-09218faea7c9c8005                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-05bdb4dd1e24ccee0                           | pcx-05bdb4dd1e24ccee0                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc-peering-connection/pcx-0bc25dcadff6cc0eb                           | pcx-0bc25dcadff6cc0eb                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:subnet/subnet-029c73efb1edc8c02                                        | subnet-029c73efb1edc8c02                                  | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:subnet/subnet-06492de38839959b5                                        | subnet-06492de38839959b5                                  | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:security-group/sg-004d2457414c2feaf                                    | sg-004d2457414c2feaf                                      | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-0141f4b1eb1d99abe                                      | rtb-0141f4b1eb1d99abe                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-099e94a7d8c5ac7da                                      | rtb-099e94a7d8c5ac7da                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-0be90165e3db9786f                                      | rtb-0be90165e3db9786f                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-0bd8e571705310954                                      | rtb-0bd8e571705310954                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-065a2136d4ea51ca0                                      | rtb-065a2136d4ea51ca0                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:route-table/rtb-0f7bd08b6396ab2fd                                      | rtb-0f7bd08b6396ab2fd                                     | delete | complete |
| arn:aws:ec2:eu-west-1:485026278258:vpc/vpc-0fe57927411acf86c                                              | vpc-0fe57927411acf86c                                     | delete | complete |
+-----------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+--------+----------+
```


